### PR TITLE
Add COMPACT RetsFormat enum value

### DIFF
--- a/src/models/RetsFormat.ts
+++ b/src/models/RetsFormat.ts
@@ -3,6 +3,10 @@
  */
 export enum RetsFormat {
     /**
+     * Compact data (usually TSV)
+     */
+    Compact = 'COMPACT',
+    /**
      * Compact decoded data (usually TSV)
      */
     CompactDecoded = 'COMPACT-DECODED',


### PR DESCRIPTION
This format generally returns shorter encoded identifiers than the compact-decoded format.