### PR TITLE
FIX: Lowercase headers breaks response parsing

### DIFF
--- a/src/tools/processHeaders.ts
+++ b/src/tools/processHeaders.ts
@@ -1,7 +1,13 @@
 import { trim } from 'lodash';
 
 export function normalizeKey(input: string): string {
-    return input.replace(/[\s-]+/g, '');
+    // some servers return lowercase headers
+    return input.split(/[\s-]+/g).map(part => {
+      if(/^[a-z]/.test(part) === true) {
+        return part.charAt(0).toUpperCase() + part.slice(1)
+      }
+      return part
+    }).join('');
 }
 
 export function processHeaders(headers?: string[]): { [key: string]: string | string[] } {


### PR DESCRIPTION
Some servers return lowercased headers which breaks parsing.

This PR includes a fix for lowercased headers. 

It might be prudent to do a more thorough fix and actually lowercase all incoming headers since _technically_ headers are case insensitive according to the specifications. 