### PR TITLE
Fix typo in RetsQueryStandardNamesType enum case

### DIFF
--- a/src/models/RetsQueryStandardNamesType.ts
+++ b/src/models/RetsQueryStandardNamesType.ts
@@ -9,5 +9,5 @@ export enum RetsQueryStandardNamesType {
     /**
      * Use StandardName for query
      */
-    UseStandarsName = 1
+    UseStandardName = 1
 }


### PR DESCRIPTION
UseStandarsName -> UseStandardName